### PR TITLE
Make multi block processing parallizeable (#51)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "auto_impl"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +346,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -881,6 +905,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,7 +1137,9 @@ dependencies = [
  "gumdrop",
  "hex",
  "itertools",
+ "log",
  "once_cell",
+ "pretty_env_logger",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -1405,6 +1440,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+dependencies = [
+ "env_logger",
+ "log",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1506,12 @@ checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1963,6 +2014,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,6 +2459,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ rust_decimal = { version = "1.10.0", features = ["db-postgres", "db-tokio-postgr
 gumdrop = "0.8.0"
 futures = "0.3.8"
 hex = "0.4.2"
+log = "0.4.14"
+pretty_env_logger = "0.4.0"
 
 [features]
 postgres-tests = []

--- a/src/inspectors/mod.rs
+++ b/src/inspectors/mod.rs
@@ -26,7 +26,7 @@ pub use erc20::ERC20;
 
 mod batch;
 /// Takes multiple inspectors
-pub use batch::BatchInspector;
+pub use batch::{BatchEvaluationError, BatchInspector};
 
 mod compound;
 pub use compound::Compound;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub use traits::*;
 
 /// PostGres trait implementations
 mod mevdb;
-pub use mevdb::MevDB;
+pub use mevdb::{BatchInserts, MevDB};
 
 mod prices;
 pub use prices::HistoricalPrice;

--- a/src/mevdb.rs
+++ b/src/mevdb.rs
@@ -1,19 +1,25 @@
+use crate::inspectors::BatchEvaluationError;
 use crate::types::Evaluation;
+use ethers::prelude::Middleware;
 use ethers::types::{TxHash, U256};
+use futures::{Future, FutureExt, Stream, StreamExt};
 use rust_decimal::prelude::*;
+use std::collections::VecDeque;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use thiserror::Error;
 use tokio_postgres::{config::Config, Client, NoTls};
 
 /// Wrapper around PostGres for storing results in the database
-pub struct MevDB<'a> {
+pub struct MevDB {
     client: Client,
-    table_name: &'a str,
+    table_name: String,
     overwrite: String,
 }
 
-impl<'a> MevDB<'a> {
+impl MevDB {
     /// Connects to the MEV PostGres instance
-    pub async fn connect(cfg: Config, table_name: &'a str) -> Result<MevDB<'a>, DbError> {
+    pub async fn connect(cfg: Config, table_name: impl Into<String>) -> Result<Self, DbError> {
         let (client, connection) = cfg.connect(NoTls).await?;
 
         tokio::spawn(async move {
@@ -26,7 +32,7 @@ impl<'a> MevDB<'a> {
         let overwrite = "on conflict do nothing";
         Ok(Self {
             client,
-            table_name,
+            table_name: table_name.into(),
             overwrite: overwrite.to_owned(),
         })
     }
@@ -159,6 +165,155 @@ pub enum DbError {
 
     #[error(transparent)]
     TokioPostGres(#[from] tokio_postgres::Error),
+}
+
+type EvalInsertion = Pin<Box<dyn Future<Output = Result<(Evaluation, MevDB), (MevDB, DbError)>>>>;
+
+type EvaluationStream<'a, M> =
+    Pin<Box<dyn Stream<Item = Result<Evaluation, BatchEvaluationError<M>>> + 'a>>;
+
+/// Takes a stream of `Evaluation`s and puts it in the database
+pub struct BatchInserts<'a, M: Middleware + Unpin + 'static> {
+    mev_db: Option<MevDB>,
+    /// The currently running insert job
+    insertion: Option<EvalInsertion>,
+    /// `Evaluation`s ready to insert
+    insertion_queue: VecDeque<Evaluation>,
+    /// All the evaluations to insert
+    pending_evaluations: EvaluationStream<'a, M>,
+    /// Whether no more evaluations are coming
+    evals_done: bool,
+}
+
+impl<'a, M: Middleware + Unpin + 'static> BatchInserts<'a, M> {
+    pub fn new<S>(mev_db: MevDB, evals: S) -> Self
+    where
+        S: Stream<Item = Result<Evaluation, BatchEvaluationError<M>>> + 'a,
+    {
+        Self {
+            mev_db: Some(mev_db),
+            insertion: None,
+            insertion_queue: VecDeque::new(),
+            pending_evaluations: Box::pin(evals),
+            evals_done: false,
+        }
+    }
+
+    /// Returns the database again
+    ///
+    /// If the DB is currently busy, this waits until the last job is completed
+    pub async fn get_database(mut self) -> MevDB {
+        if let Some(db) = self.mev_db.take() {
+            db
+        } else {
+            match self.insertion.expect("DB is busy when not idle").await {
+                Ok((_, db)) => db,
+                Err((db, _)) => db,
+            }
+        }
+    }
+}
+
+impl<'a, M: Middleware + Unpin> Stream for BatchInserts<'a, M> {
+    type Item = Result<Evaluation, InsertEvaluationError<M>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        // start a new insert if ready
+        if let Some(db) = this.mev_db.take() {
+            if let Some(next) = this.insertion_queue.pop_front() {
+                log::trace!(
+                    "start next evaluation insert, {} pending",
+                    this.insertion_queue.len()
+                );
+                this.insertion = Some(Box::pin(insert_evaluation(next, db)));
+            } else {
+                this.mev_db = Some(db);
+            }
+        }
+
+        // complete the insertion task
+        if let Some(mut job) = this.insertion.take() {
+            match job.poll_unpin(cx) {
+                Poll::Ready(Ok((eval, db))) => {
+                    this.mev_db = Some(db);
+                    return Poll::Ready(Some(Ok(eval)));
+                }
+                Poll::Ready(Err((db, err))) => {
+                    this.mev_db = Some(db);
+                    return Poll::Ready(Some(Err(err.into())));
+                }
+                Poll::Pending => {
+                    this.insertion = Some(job);
+                }
+            }
+        }
+
+        if !this.evals_done {
+            // queue in all evaluations that are coming in
+            loop {
+                match this.pending_evaluations.poll_next_unpin(cx) {
+                    Poll::Ready(Some(Ok(eval))) => {
+                        log::trace!(
+                            "received new evaluation of block {} with tx {}; waiting evaluations: {}",
+                            eval.inspection.block_number,
+                            eval.inspection.hash,
+                            this.insertion_queue.len() + 1
+                        );
+                        this.insertion_queue.push_back(eval);
+                    }
+                    Poll::Ready(Some(Err(err))) => return Poll::Ready(Some(Err(err.into()))),
+                    Poll::Ready(None) => {
+                        log::trace!("evaluations done");
+                        this.evals_done = true;
+                        break;
+                    }
+                    Poll::Pending => break,
+                }
+            }
+        }
+
+        // If more evaluations and insertions are processed we're not done yet
+        if this.evals_done && this.insertion_queue.is_empty() && this.insertion.is_none() {
+            log::trace!("batch insert done");
+            Poll::Ready(None)
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let insertions = self.insertion_queue.len() + self.insertion.is_some() as usize;
+        let (evals, _) = self.pending_evaluations.size_hint();
+        (insertions + evals, None)
+    }
+}
+
+async fn insert_evaluation(
+    eval: Evaluation,
+    mut db: MevDB,
+) -> Result<(Evaluation, MevDB), (MevDB, DbError)> {
+    if let Err(err) = db.insert(&eval).await {
+        log::error!("DB insert failed: {:?}", err);
+        Err((db, err))
+    } else {
+        log::debug!(
+            "inserted evaluation of block {} with tx {}",
+            eval.inspection.block_number,
+            eval.inspection.hash
+        );
+        Ok((eval, db))
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum InsertEvaluationError<M: Middleware + 'static> {
+    #[error(transparent)]
+    DbError(#[from] DbError),
+
+    #[error(transparent)]
+    BatchEvaluationError(#[from] BatchEvaluationError<M>),
 }
 
 // helpers


### PR DESCRIPTION
* refactor: remove lifetime requirement of mevdb in favor of owned table name

* feat: add support for batch processing for blocks

* feat: add support for async block processing and inserting

* refactor: use block batch processing for block argument

* refactor: make multi block processing parallelized

* chore(clippy): make clippy happy

* fix: fix insertion polling order

* fix: drop sender to make sure channel gets closed

* feat: add logging

* feat: add option to set max concurrent requests

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
